### PR TITLE
First cut at automatically pushing to nuget.org when GitHub Release is published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+
+name: Publish Release to NuGet
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-to-nuget:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 6.0.x
+      - name: Release Build & Pack CosmosDB.Extensions.SessionTokens.AspNetCore
+        run: >
+         dotnet pack 
+         --configuration Release 
+         -p:ContinuousIntegrationBuild=true
+         -p:PackageVersion=${{ github.event.release.tag_name }}
+         src\CosmosDB.Extensions.SessionTokens.AspNetCore\CosmosDB.Extensions.SessionTokens.AspNetCore.csproj
+      - name: Publish CosmosDB.Extensions.SessionTokens.AspNetCore to int.nugettest.org
+        run: >
+          dotnet nuget push 
+          src\CosmosDB.Extensions.SessionTokens.AspNetCore\bin\Release\CosmosDB.Extensions.SessionTokens.AspNetCore.${{ github.event.release.tag_name }}.nupkg
+          --source https://int.nugettest.org/v3/index.json
+          --api-key ${{ secrets.NUGETTEST_API_KEY }}

--- a/src/CosmosDB.Extensions.SessionTokens.AspNetCore/CosmosDB.Extensions.SessionTokens.AspNetCore.csproj
+++ b/src/CosmosDB.Extensions.SessionTokens.AspNetCore/CosmosDB.Extensions.SessionTokens.AspNetCore.csproj
@@ -1,5 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <Sdk Name="Microsoft.DotNet.PackageValidation" Version="1.0.0-preview.7.21379.12" />
+
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
@@ -13,6 +15,13 @@
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/pmalmsten/cosmosdb-extensions-sessiontokens-aspnet</PackageProjectUrl>
         <Authors>Paul Malmsten</Authors>
+        <Copyright>Copyright (c) Microsoft 2022</Copyright>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
 
     <ItemGroup>
@@ -20,9 +29,14 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Castle.Core" Version="5.1.0" />
-      <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.31.2" />
-      <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+        <PackageReference Include="Castle.Core" Version="5.1.0"/>
+        <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.31.2"/>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    </ItemGroup>
+    
+    <ItemGroup>
+        <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
First cut at automating pushes to nuget.org on publish of a Release in GitHub. To start, this PR publishes to int.nugettest.org

This PR also adds useful additional metadata to the CosmosDB.Extensions.SessionTokens.AspNetCore and configures SourceLink for it.