### PR TITLE
Naming tweak: int.nugettest.org -> nuget.org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
          -p:ContinuousIntegrationBuild=true
          -p:PackageVersion=${{ github.event.release.tag_name }}
          src/CosmosDB.Extensions.SessionTokens.AspNetCore/CosmosDB.Extensions.SessionTokens.AspNetCore.csproj
-      - name: Publish CosmosDB.Extensions.SessionTokens.AspNetCore to int.nugettest.org
+      - name: Publish CosmosDB.Extensions.SessionTokens.AspNetCore to nuget.org
         run: >
           dotnet nuget push 
           src/CosmosDB.Extensions.SessionTokens.AspNetCore/bin/Release/CosmosDB.Extensions.SessionTokens.AspNetCore.${{ github.event.release.tag_name }}.nupkg


### PR DESCRIPTION
Fixes the name of the release workflow step that
pushes to nuget in order to match the fact that
the workflow now pushes to the prod nuget instance
instead of the integ test one.