### PR TITLE
Reduce verbosity of Container call interception logging, improve documentation

### DIFF
--- a/src/CosmosDB.Extensions.SessionTokens.AspNetCore/CosmosDB.Extensions.SessionTokens.AspNetCore.csproj
+++ b/src/CosmosDB.Extensions.SessionTokens.AspNetCore/CosmosDB.Extensions.SessionTokens.AspNetCore.csproj
@@ -29,14 +29,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Castle.Core" Version="5.1.0"/>
-        <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.31.2"/>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0"/>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+        <PackageReference Include="Castle.Core" Version="5.1.0" />
+        <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.31.2" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     </ItemGroup>
     
     <ItemGroup>
-        <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+        <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
All existing debug logs on CosmosDbContainerInterceptor.cs are reduced to trace, except for two new debug logs added here: 1) a log statement indicating whether a session token was injected into a method call,and 2) a log statement indicating whether a session token was captured from a method call. 

Additionally, comments are added to CosmosDbContainerInterceptor.cs explaining the nuances of double dynamic dispatch, and the signatures of a few private methods are simplified.