### PR TITLE
Add unit tests, fix session token capturing for *StreamAsync methods

### DIFF
--- a/tests/CosmosDB.Extensions.SessionTokens.AspNetCore.UnitTests/CosmosDB.Extensions.SessionTokens.AspNetCore.UnitTests.csproj
+++ b/tests/CosmosDB.Extensions.SessionTokens.AspNetCore.UnitTests/CosmosDB.Extensions.SessionTokens.AspNetCore.UnitTests.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Divergic.Logging.Xunit" Version="4.2.0" />
         <PackageReference Include="FakeItEasy" Version="7.3.1" />
         <PackageReference Include="FluentAssertions" Version="6.8.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />


### PR DESCRIPTION
Container methods CreateItemStreamAsync and ReplaceItemStreamAsync now extract session tokens properly from the Cosmos DB SDK ResponseMessage return value.