### PR TITLE
CosmosDbContainerInterceptor now properly intercepts Container methods

### DIFF
--- a/src/CosmosDB.Extensions.SessionTokens.AspNetCore/CosmosDB.Extensions.SessionTokens.AspNetCore.csproj
+++ b/src/CosmosDB.Extensions.SessionTokens.AspNetCore/CosmosDB.Extensions.SessionTokens.AspNetCore.csproj
@@ -30,6 +30,7 @@
 
     <ItemGroup>
         <PackageReference Include="Castle.Core" Version="[5,6)" />
+        <PackageReference Include="Castle.Core.AsyncInterceptor" Version="2.1.0" />
         <PackageReference Include="Microsoft.Azure.Cosmos" Version="[3.26,4)" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />

--- a/src/CosmosDB.Extensions.SessionTokens.AspNetCore/Interceptors/CosmosDbContainerInterceptor.cs
+++ b/src/CosmosDB.Extensions.SessionTokens.AspNetCore/Interceptors/CosmosDbContainerInterceptor.cs
@@ -154,14 +154,14 @@ public class CosmosDbContainerInterceptor<T> : IAsyncInterceptor
                     if (sessionTokenForContextAndDatabase != null)
                     {
                         sessionTokenProperty.SetValue(argumentValue, sessionTokenForContextAndDatabase);
-                        _logger.LogTrace(
+                        _logger.LogDebug(
                             "SessionToken property set on RequestOptions param at position {RequestOptionsParameterIndex}",
                             i);
                         sessionTokenInjectedIntoCallParams = true;
                     }
                     else
                     {
-                        _logger.LogTrace("Session token from manager is null, doing nothing");
+                        _logger.LogDebug("Session token from manager is null, doing nothing");
                     }
                 }
                 else
@@ -216,7 +216,7 @@ public class CosmosDbContainerInterceptor<T> : IAsyncInterceptor
         }
         else
         {
-            _logger.LogTrace(
+            _logger.LogDebug(
                 "Session Token not captured - return value did not have a 'Headers' property. Return value type was {ReturnValueType}",
                 returnValueType);
         }
@@ -248,10 +248,12 @@ public class CosmosDbContainerInterceptor<T> : IAsyncInterceptor
                     sessionTokenCapturedFromRead ? SessionTokenSource.FromRead : SessionTokenSource.FromWrite,
                     sessionTokenString
                 ));
-            _logger.LogTrace("Session token was saved");
+            _logger.LogDebug("Session token was saved");
         }
-
-        _logger.LogWarning(
-            "Current context is null, this call flow is not currently within a tracked context. Session token not saved");
+        else
+        {
+            _logger.LogWarning(
+                "Current context is null, this call flow is not currently within a tracked context. Session token not saved");
+        }
     }
 }

--- a/src/CosmosDB.Extensions.SessionTokens.AspNetCore/Interceptors/CosmosDbContainerInterceptor.cs
+++ b/src/CosmosDB.Extensions.SessionTokens.AspNetCore/Interceptors/CosmosDbContainerInterceptor.cs
@@ -38,7 +38,8 @@ public class CosmosDbContainerInterceptor<T> : IAsyncInterceptor
     public void InterceptSynchronous(IInvocation invocation)
     {
         using var scope = _logger.BeginScope(
-            "Invocation of {MethodName}, assigned invocation ID {InvocationId}", invocation.Method.Name,
+            "Invocation of {MethodName}, assigned invocation ID {InvocationId}", 
+            invocation.Method.Name,
             Guid.NewGuid());
         _logger.LogTrace("Entering synchronous invocation");
 
@@ -61,7 +62,8 @@ public class CosmosDbContainerInterceptor<T> : IAsyncInterceptor
     public void InterceptAsynchronous(IInvocation invocation)
     {
         using var scope = _logger.BeginScope(
-            "Invocation of {MethodName}, assigned invocation ID {InvocationId}", invocation.Method.Name,
+            "Invocation of {MethodName}, assigned invocation ID {InvocationId}", 
+            invocation.Method.Name,
             Guid.NewGuid());
         _logger.LogTrace("Entering async invocation with no result");
 
@@ -89,7 +91,8 @@ public class CosmosDbContainerInterceptor<T> : IAsyncInterceptor
     public void InterceptAsynchronous<TResult>(IInvocation invocation)
     {
         using var scope = _logger.BeginScope(
-            "Invocation of {MethodName}, assigned invocation ID {InvocationId}", invocation.Method.Name,
+            "Invocation of {MethodName}, assigned invocation ID {InvocationId}", 
+            invocation.Method.Name,
             Guid.NewGuid());
         _logger.LogTrace("Entering async invocation with result");
 
@@ -205,7 +208,7 @@ public class CosmosDbContainerInterceptor<T> : IAsyncInterceptor
 
         if (returnValueHeadersProperty != null && returnValueHeadersProperty.PropertyType == typeof(Headers))
         {
-            _logger.LogDebug("Found Headers property on return value - attempting to capture Session Token value.");
+            _logger.LogDebug("Found Headers property on return value - attempting to capture Session Token value");
             var headersPropertyValue = (Headers?) returnValueHeadersProperty.GetValue(returnValue);
             var sessionTokenString = headersPropertyValue?.Session;
         

--- a/src/CosmosDB.Extensions.SessionTokens.AspNetCore/Middleware/CosmosDbSessionTokenHttpMiddleware.cs
+++ b/src/CosmosDB.Extensions.SessionTokens.AspNetCore/Middleware/CosmosDbSessionTokenHttpMiddleware.cs
@@ -34,7 +34,7 @@ public abstract class CosmosDbSessionTokenHttpMiddleware
             return Task.CompletedTask;
         });
 
-        await _next(context);
+        await _next(context).ConfigureAwait(false);
     }
 
     /// <summary>


### PR DESCRIPTION
Previously, CosmosDbContainerInterceptor both 1) did not intercept async method invocations properly, and 2) did not extract session tokens from SDK return values properly. Both of these parts of the interceptor used the 'dynamic' type combined with a method call to dynamically dispatch to the correct method overload at runtime. 

This worked great during unit & integration testing with FakeItEasy stubs, but flopped during end-to-end testing with the real Cosmos SDK. 

The first problem (intercepting async method invocations properly) was resolved by adopting the Castle.Core.AsyncInterceptor library and rewriting CosmosDbContainerInterceptor to use IAsyncInterceptor instead of 'dynamic'. 

The second problem was resolved by using direct introspection instead of using 'dynamic' - instead of trying to use 'dynamic' to dispatch to different method overloads according to the type of the return value, it now simply looks for the presence of a 'Headers' property having the correct type on the return value, and if one is present, tries to extract the session token from there. 

With these fixes, end-to-end testing now shows session tokens being captured and propagated by this interceptor as intended. These were tricky problems that are difficult to replicate in unit tests - I think one moral of the story here is that any use of 'dynamic' might be a code smell and deserves particular scrutiny. 

One last footnote - this change also sets .ConfigureAwait(false) on all awaits in production code.