### PR TITLE
Fix minor warnings in SynchronizedLogger (test code)

### DIFF
--- a/tests/CosmosDB.Extensions.SessionTokens.AspNetCore.IntegrationTests/Util/SynchronizedLogger.cs
+++ b/tests/CosmosDB.Extensions.SessionTokens.AspNetCore.IntegrationTests/Util/SynchronizedLogger.cs
@@ -27,7 +27,7 @@ internal class SynchronizedLogger : ILogger
         }
     }
 
-    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
+    public IDisposable BeginScope<TState>(TState state)
     {
         lock (_globalLogLock)
         {


### PR DESCRIPTION
Fixes a minor compiler warning in SynchronizedLogger, a utility library used by automated test code.