### PR TITLE
Add manual testing client to test projects

### DIFF
--- a/cosmosdb-extensions-sessiontokens-aspnet.sln
+++ b/cosmosdb-extensions-sessiontokens-aspnet.sln
@@ -10,6 +10,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CosmosDB.Extensions.Session
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CosmosDB.Extensions.SessionTokens.AspNetCore.IntegrationTestsWebAPI", "tests\CosmosDB.Extensions.SessionTokens.AspNetCore.IntegrationTestsWebAPI\CosmosDB.Extensions.SessionTokens.AspNetCore.IntegrationTestsWebAPI.csproj", "{A55682F9-44DC-4FFF-8AA1-10555CD98E03}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CosmosDB.Extensions.SessionTokens.AspNetCore.ManualTestClient", "tests\CosmosDB.Extensions.SessionTokens.AspNetCore.ManualTestClient\CosmosDB.Extensions.SessionTokens.AspNetCore.ManualTestClient.csproj", "{7156B8E9-A849-483A-914B-0E4EB1FD4263}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,10 +34,15 @@ Global
 		{A55682F9-44DC-4FFF-8AA1-10555CD98E03}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A55682F9-44DC-4FFF-8AA1-10555CD98E03}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A55682F9-44DC-4FFF-8AA1-10555CD98E03}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7156B8E9-A849-483A-914B-0E4EB1FD4263}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7156B8E9-A849-483A-914B-0E4EB1FD4263}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7156B8E9-A849-483A-914B-0E4EB1FD4263}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7156B8E9-A849-483A-914B-0E4EB1FD4263}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{1524AA66-E983-43C8-87F9-F462005DF409} = {A105E34F-1CB5-496E-9BBD-44E3F70E7AF1}
 		{CAB2635D-A6EC-4AF6-9020-496C2C37BFFB} = {A105E34F-1CB5-496E-9BBD-44E3F70E7AF1}
 		{A55682F9-44DC-4FFF-8AA1-10555CD98E03} = {A105E34F-1CB5-496E-9BBD-44E3F70E7AF1}
+		{7156B8E9-A849-483A-914B-0E4EB1FD4263} = {A105E34F-1CB5-496E-9BBD-44E3F70E7AF1}
 	EndGlobalSection
 EndGlobal

--- a/tests/CosmosDB.Extensions.SessionTokens.AspNetCore.ManualTestClient/CosmosDB.Extensions.SessionTokens.AspNetCore.ManualTestClient.csproj
+++ b/tests/CosmosDB.Extensions.SessionTokens.AspNetCore.ManualTestClient/CosmosDB.Extensions.SessionTokens.AspNetCore.ManualTestClient.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <RootNamespace>CosmosDB.Extensions.SessionTokens.AspNetCore.ManualTestClient</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Flurl.Http" Version="3.2.4" />
+    </ItemGroup>
+
+</Project>

--- a/tests/CosmosDB.Extensions.SessionTokens.AspNetCore.ManualTestClient/Program.cs
+++ b/tests/CosmosDB.Extensions.SessionTokens.AspNetCore.ManualTestClient/Program.cs
@@ -1,0 +1,76 @@
+﻿
+using Flurl.Http;
+using Newtonsoft.Json;
+
+var apiBaseUrl = "http://localhost/Counter";
+var cookieJar = new CookieJar();
+
+for (int i = 0; i < 5; i++)
+{
+    var counterValueBeforeWrite = await apiBaseUrl
+        .WithCookies(cookieJar)
+        .GetJsonAsync<Counter>();
+    Console.WriteLine($"Counter value before write: {counterValueBeforeWrite.Count}");
+
+    var incrementedCounterValue = await apiBaseUrl
+        .WithCookies(cookieJar)
+        .PostAsync()
+        .ReceiveJson<Counter>();
+
+    Console.WriteLine($"Counter incremented to: {incrementedCounterValue.Count}");
+
+    for (int j = 0; j < 15; j++)
+    {
+        var request = apiBaseUrl.WithCookies(cookieJar);
+        var response = await request.GetAsync();
+        
+        var currentCounterValue = await response.GetJsonAsync<Counter>();
+
+        var anyCookiesSent = request.Cookies.Any();
+        var anyCookiesReceived = response.Cookies.Any();
+        var readWasConsistent = currentCounterValue.Count == incrementedCounterValue.Count;
+
+        PrintWhetherReadWasConsistentToConsole(readWasConsistent, currentCounterValue, anyCookiesSent, anyCookiesReceived);
+    }
+}
+
+void PrintWhetherReadWasConsistentToConsole(bool readWasConsistent, Counter counter, bool anyCookiesSent, bool anyCookiesReceived)
+{
+    ChangeConsoleColorForInconsistentResponses(readWasConsistent);
+    Console.Write($"Read counter value: {counter.Count}");
+    if (!readWasConsistent)
+    {
+        Console.Write(" (inconsistent)");
+    }
+    
+    if (anyCookiesSent)
+    {
+        Console.Write(" (cookies sent)");
+    }
+    
+    if (anyCookiesReceived)
+    {
+        Console.Write(" (cookies received)");
+    }
+
+    Console.ResetColor();
+    Console.WriteLine();
+}
+
+void ChangeConsoleColorForInconsistentResponses(bool readWasConsistent)
+{
+    Console.ForegroundColor = ConsoleColor.White;
+    if (readWasConsistent)
+    {
+        Console.BackgroundColor = ConsoleColor.DarkGreen;
+    }
+    else
+    {
+        Console.BackgroundColor = ConsoleColor.DarkYellow;
+        Console.ForegroundColor = ConsoleColor.Black;
+    }
+}
+
+record Counter(
+    [property:JsonProperty("id")] string Id, 
+    [property:JsonProperty("count")] int Count);

--- a/tests/CosmosDB.Extensions.SessionTokens.AspNetCore.ManualTestClient/README.md
+++ b/tests/CosmosDB.Extensions.SessionTokens.AspNetCore.ManualTestClient/README.md
@@ -1,0 +1,9 @@
+## Manual Test Client for Integration Tests Web API
+
+This is a simple console application that can be used to send end-to-end requests to the integration tests Web API.
+
+### How to Use
+
+1. Follow the instructions in the [integration tests Web API README](../CosmosDB.Extensions.SessionTokens.AspNetCore.IntegrationTestsWebAPI/README.md)
+   to start the Web API on Kubernetes and start a local tunnel to minikube.
+2. In this project's directory, run: `dotnet run`


### PR DESCRIPTION
Adds a console application for generating requests to the Counter APIs in the integration tests 
web API project. Useful for performing manual end-to-end tests against a real ASP.NET Core
Web API server and Cosmos DB account.